### PR TITLE
Migrate controllers to standard architecture (#37)

### DIFF
--- a/src/main/java/com/wotos/wotosplayerservice/controller/PlayerAchievementsController.java
+++ b/src/main/java/com/wotos/wotosplayerservice/controller/PlayerAchievementsController.java
@@ -2,19 +2,35 @@ package com.wotos.wotosplayerservice.controller;
 
 import com.wotos.wotosplayerservice.dao.PlayerAchievementsSnapshot;
 import com.wotos.wotosplayerservice.service.PlayerAchievementsService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.Map;
 
+/**
+ * REST endpoints for retrieving and creating {@link PlayerAchievementsSnapshot}s for a set
+ * of player accounts.
+ */
 @RestController
 @RequestMapping("/api/player")
 public class PlayerAchievementsController {
 
-    @Autowired
-    PlayerAchievementsService playerAchievementsService;
+    private final PlayerAchievementsService playerAchievementsService;
 
+    public PlayerAchievementsController(PlayerAchievementsService playerAchievementsService) {
+        this.playerAchievementsService = playerAchievementsService;
+    }
+
+    /**
+     * Returns the stored achievement snapshots per account.
+     *
+     * @param accountIds the account ids to look up
+     * @return a map of account id to the ordered list of {@link PlayerAchievementsSnapshot}
+     */
     @GetMapping("/achievements")
     public Map<Integer, List<PlayerAchievementsSnapshot>> getPlayerAchievementsByAccountIds(
             @RequestParam("accountIds") Integer[] accountIds
@@ -22,11 +38,17 @@ public class PlayerAchievementsController {
         return playerAchievementsService.getPlayerAchievementsSnapshotsByAccountIds(accountIds);
     }
 
+    /**
+     * Creates and persists a fresh achievement snapshot per account from the current WoT API.
+     *
+     * @param accountIds the account ids to snapshot
+     * @return a map of account id to the newly-created {@link PlayerAchievementsSnapshot}
+     * @throws feign.FeignException if the upstream WoT API call fails
+     */
     @PostMapping("/achievements")
     public Map<Integer, PlayerAchievementsSnapshot> createPlayerAchievementsByAccountIds(
             @RequestParam("accountIds") Integer[] accountIds
     ) {
         return playerAchievementsService.createPlayerAchievementsSnapshotsByAccountIds(accountIds);
     }
-
 }

--- a/src/main/java/com/wotos/wotosplayerservice/controller/PlayerController.java
+++ b/src/main/java/com/wotos/wotosplayerservice/controller/PlayerController.java
@@ -5,61 +5,114 @@ import com.wotos.wotosplayerservice.service.PlayerService;
 import com.wotos.wotosplayerservice.util.model.wot.player.WotPlayer;
 import com.wotos.wotosplayerservice.validation.constraints.Language;
 import com.wotos.wotosplayerservice.validation.constraints.PlayerSearch;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.constraints.Max;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * REST endpoints for the player resource: search, lookup, creation, and refresh of persisted
+ * player records, plus a freshness check against the Wargaming/WoT API.
+ *
+ * <p>Exceptions thrown from these endpoints are translated to a consistent error payload by
+ * {@code GlobalExceptionHandler}.
+ */
 @RestController
-@RequestMapping("/api/player")
+@RequestMapping("/api/players")
 @Validated
 public class PlayerController {
 
-    @Autowired
-    PlayerService playerService;
+    private final PlayerService playerService;
 
+    public PlayerController(PlayerService playerService) {
+        this.playerService = playerService;
+    }
+
+    /**
+     * Indicates, per account, whether the persisted player record is older than the upstream
+     * WoT record.
+     *
+     * @param accountIds the account ids to check
+     * @return a map of account id to {@code true} when the local record is stale
+     * @throws feign.FeignException if the upstream WoT API call fails
+     */
     @GetMapping("/haveUpdated")
     public ResponseEntity<Map<Integer, Boolean>> havePlayersBeenUpdated(
             @RequestParam("accountIds") Integer[] accountIds
     ) {
-        return new ResponseEntity<>(playerService.havePlayersBeenUpdated(accountIds), HttpStatus.OK);
+        return ResponseEntity.ok(playerService.havePlayersBeenUpdated(accountIds));
     }
 
+    /**
+     * Returns the persisted player records for the given account ids.
+     *
+     * @param accountIds the account ids to look up
+     * @return a map of account id to {@link PlayerDetails}; missing ids map to {@code null}
+     */
     @GetMapping
-    public Map<Integer, PlayerDetails> getPlayersMapByAccountIds(
+    public ResponseEntity<Map<Integer, PlayerDetails>> getPlayersMapByAccountIds(
             @RequestParam(value = "accountIds") Integer[] accountIds
     ) {
-        return playerService.getPlayersMapByAccountIds(accountIds);
+        return ResponseEntity.ok(playerService.getPlayersMapByAccountIds(accountIds));
     }
 
+    /**
+     * Fetches the given accounts from the WoT API and persists any that are not yet stored.
+     *
+     * @param accountIds the account ids to create
+     * @return {@code 201 Created} with a map of account id to the persisted {@link PlayerDetails}
+     * @throws feign.FeignException if the upstream WoT API call fails
+     */
     @PostMapping
-    public Map<Integer, PlayerDetails> createPlayersByAccountIds(
+    public ResponseEntity<Map<Integer, PlayerDetails>> createPlayersByAccountIds(
             @RequestParam(value = "accountIds") Integer[] accountIds
     ) {
-        return playerService.createPlayersByAccountIds(accountIds);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(playerService.createPlayersByAccountIds(accountIds));
     }
 
+    /**
+     * Refreshes the persisted player records for the given accounts from the WoT API.
+     *
+     * @param accountIds the account ids to update
+     * @return a map of account id to the refreshed {@link PlayerDetails}
+     * @throws feign.FeignException if the upstream WoT API call fails
+     */
     @PutMapping
-    public Map<Integer, PlayerDetails> updatePlayersByAccountIds(
+    public ResponseEntity<Map<Integer, PlayerDetails>> updatePlayersByAccountIds(
             @RequestParam(value = "accountIds") Integer[] accountIds
     ) {
-        return playerService.updatePlayersByAccountId(accountIds);
+        return ResponseEntity.ok(playerService.updatePlayersByAccountId(accountIds));
     }
 
+    /**
+     * Searches the WoT API for players matching one or more nicknames.
+     *
+     * @param nicknames  the nicknames to search for
+     * @param language   the WoT API language hint (defaults to {@code en})
+     * @param limit      optional cap on results, up to 100
+     * @param searchType the WoT search mode (e.g. {@code exact}, {@code startswith})
+     * @return matching {@link WotPlayer} records as returned by the WoT API
+     * @throws javax.validation.ConstraintViolationException if a parameter fails validation
+     * @throws feign.FeignException if the upstream WoT API call fails
+     */
     @GetMapping("/list")
     @PlayerSearch
-    public List<WotPlayer> getPlayersByNickname(
+    public ResponseEntity<List<WotPlayer>> getPlayersByNickname(
             @RequestParam(value = "nicknames") String[] nicknames,
             @RequestParam(value = "language", required = false, defaultValue = "en") @Language String language,
             @RequestParam(value = "limit", required = false) @Max(100) Integer limit,
             @RequestParam(value = "searchType") String searchType
     ) {
-        return playerService.getPlayersByNickname(nicknames, language, limit, searchType);
+        return ResponseEntity.ok(playerService.getPlayersByNickname(nicknames, language, limit, searchType));
     }
-
 }

--- a/src/main/java/com/wotos/wotosplayerservice/controller/PlayerSnapshotController.java
+++ b/src/main/java/com/wotos/wotosplayerservice/controller/PlayerSnapshotController.java
@@ -2,19 +2,35 @@ package com.wotos.wotosplayerservice.controller;
 
 import com.wotos.wotosplayerservice.dao.PlayerSnapshot;
 import com.wotos.wotosplayerservice.service.PlayerSnapshotService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.Map;
 
+/**
+ * REST endpoints for retrieving and creating point-in-time {@link PlayerSnapshot}s for a set
+ * of player accounts.
+ */
 @RestController
 @RequestMapping("/api/player")
 public class PlayerSnapshotController {
 
-    @Autowired
-    PlayerSnapshotService playerSnapshotService;
+    private final PlayerSnapshotService playerSnapshotService;
 
+    public PlayerSnapshotController(PlayerSnapshotService playerSnapshotService) {
+        this.playerSnapshotService = playerSnapshotService;
+    }
+
+    /**
+     * Returns the stored snapshot history for each account.
+     *
+     * @param accountIds the account ids to look up
+     * @return a map of account id to the ordered list of {@link PlayerSnapshot}
+     */
     @GetMapping("/snapshots")
     public Map<Integer, List<PlayerSnapshot>> getPlayerSnapshotsByAccountIds(
             @RequestParam("accountIds") Integer[] accountIds
@@ -22,11 +38,17 @@ public class PlayerSnapshotController {
         return playerSnapshotService.getPlayerSnapshotsByAccountIds(accountIds);
     }
 
+    /**
+     * Creates and persists a fresh snapshot per account from the current WoT API data.
+     *
+     * @param accountIds the account ids to snapshot
+     * @return a map of account id to the newly-created {@link PlayerSnapshot}
+     * @throws feign.FeignException if the upstream WoT API call fails
+     */
     @PostMapping("/snapshots")
     public Map<Integer, PlayerSnapshot> createPlayerSnapshotsByAccountIds(
             @RequestParam("accountIds") Integer[] accountIds
     ) {
         return playerSnapshotService.createPlayerSnapshotByAccountIds(accountIds);
     }
-
 }


### PR DESCRIPTION
Closes #37. Depends on the now-merged #36.

## Changes

### All three controllers
- **Constructor injection** replaces `@Autowired` field injection (testable, immutable, no reflection on private fields).
- **Javadoc** on every public endpoint method with `@param`, `@return`, and `@throws` (Feign upstream failures, validation failures where applicable).

### `PlayerController` only (per the issue's explicit scope)
- `@RequestMapping("/api/player")` → `@RequestMapping("/api/players")` — matches the README's documented contract and the edge-service path convention.
- All five endpoint methods now return `ResponseEntity<…>`:
  - `POST` → `201 Created`
  - `GET`/`PUT`/`/haveUpdated` → `200 OK`

## Scope notes
- The issue scoped the URL rename and `ResponseEntity` wrapping to `PlayerController`. `PlayerSnapshotController` and `PlayerAchievementsController` therefore still serve under `/api/player` — the README documents `/api/players/snapshots`, so a follow-up issue should align those for consistency.
- Edge-service Feign clients referencing `/api/player` need a coordinated update in `wotos-edge-service` (out of scope for this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)