### PR TITLE
Map ConstraintViolationException to 400 (#33)

### DIFF
--- a/src/main/java/com/wotos/wotosplayerservice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/wotos/wotosplayerservice/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import javax.validation.ConstraintViolationException;
 import java.util.stream.Collectors;
 
 /**
@@ -39,6 +40,29 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException ex) {
         String message = ex.getBindingResult().getFieldErrors().stream()
                 .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+
+        if (message.isEmpty()) {
+            message = "Validation failed";
+        }
+
+        return build(HttpStatus.BAD_REQUEST, message);
+    }
+
+    /**
+     * Maps bean-validation failures on request parameters (controllers annotated with
+     * {@code @Validated}, e.g. {@code @RequestParam} + {@code @Max}/{@code @Language}) to
+     * {@code 400 Bad Request}, summarizing each violated constraint.
+     *
+     * <p>Without this handler such failures would fall through to the generic 500.
+     *
+     * @param ex the constraint violation raised by Spring's parameter validation
+     * @return an {@link ErrorResponse} listing each violated parameter and its message
+     */
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolation(ConstraintViolationException ex) {
+        String message = ex.getConstraintViolations().stream()
+                .map(v -> v.getPropertyPath() + ": " + v.getMessage())
                 .collect(Collectors.joining(", "));
 
         if (message.isEmpty()) {

--- a/src/test/java/com/wotos/wotosplayerservice/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/wotos/wotosplayerservice/exception/GlobalExceptionHandlerTest.java
@@ -8,6 +8,8 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,6 +50,21 @@ public class GlobalExceptionHandlerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody().getStatus()).isEqualTo(400);
         assertThat(response.getBody().getMessage()).contains("language");
+    }
+
+    @Test
+    public void handleConstraintViolationReturns400WithViolationDetail() {
+        ConstraintViolation<?> violation = mock(ConstraintViolation.class);
+        when(violation.getMessage()).thenReturn("must be less than or equal to 100");
+
+        ConstraintViolationException ex = new ConstraintViolationException(
+                Collections.singleton(violation));
+
+        ResponseEntity<ErrorResponse> response = handler.handleConstraintViolation(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().getStatus()).isEqualTo(400);
+        assertThat(response.getBody().getMessage()).contains("must be less than or equal to 100");
     }
 
     @Test


### PR DESCRIPTION
Closes #33.

## What

`PlayerController` is annotated `@Validated` and its `@RequestParam`s carry constraints (`@Max(100)`, `@Language`, `@PlayerSearch`). When those fail, Spring raises **`javax.validation.ConstraintViolationException`**, which the merged `GlobalExceptionHandler` (#36) did not handle — so invalid input fell through to the generic **500**.

This PR adds a dedicated handler that returns **400 Bad Request** with the violated constraint's message, plus a unit test.

## Why this is the right scope for "API Validation"

The validators (`LanguageValidator`, `PlayerSearchValidator`, the `@Language`/`@PlayerSearch` constraints) already exist and fire on requests. The only thing API Validation was missing was that the resulting exception was being returned as a 500 instead of a 400 — closing that gap makes the contract correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)