### PR TITLE
Add MockMvc unit tests for the three controllers (#2)

### DIFF
--- a/src/test/java/com/wotos/wotosplayerservice/controller/PlayerAchievementsControllerTest.java
+++ b/src/test/java/com/wotos/wotosplayerservice/controller/PlayerAchievementsControllerTest.java
@@ -1,0 +1,73 @@
+package com.wotos.wotosplayerservice.controller;
+
+import com.wotos.wotosplayerservice.exception.GlobalExceptionHandler;
+import com.wotos.wotosplayerservice.service.PlayerAchievementsService;
+import feign.FeignException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.HashMap;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * MockMvc tests covering {@link PlayerAchievementsController}'s endpoint routes and the
+ * integration with {@link GlobalExceptionHandler}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PlayerAchievementsControllerTest {
+
+    @Mock
+    private PlayerAchievementsService playerAchievementsService;
+
+    @InjectMocks
+    private PlayerAchievementsController playerAchievementsController;
+
+    private MockMvc mockMvc;
+
+    @Before
+    public void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(playerAchievementsController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    public void getPlayerAchievementsByAccountIdsReturns200() throws Exception {
+        when(playerAchievementsService.getPlayerAchievementsSnapshotsByAccountIds(any()))
+                .thenReturn(new HashMap<>());
+
+        mockMvc.perform(get("/api/player/achievements").param("accountIds", "1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void createPlayerAchievementsByAccountIdsReturns200() throws Exception {
+        when(playerAchievementsService.createPlayerAchievementsSnapshotsByAccountIds(any()))
+                .thenReturn(new HashMap<>());
+
+        mockMvc.perform(post("/api/player/achievements").param("accountIds", "1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void feignExceptionFromServiceMapsTo502() throws Exception {
+        FeignException feignEx = mock(FeignException.class);
+        when(playerAchievementsService.createPlayerAchievementsSnapshotsByAccountIds(any()))
+                .thenThrow(feignEx);
+
+        mockMvc.perform(post("/api/player/achievements").param("accountIds", "1"))
+                .andExpect(status().isBadGateway());
+    }
+}

--- a/src/test/java/com/wotos/wotosplayerservice/controller/PlayerControllerTest.java
+++ b/src/test/java/com/wotos/wotosplayerservice/controller/PlayerControllerTest.java
@@ -1,0 +1,115 @@
+package com.wotos.wotosplayerservice.controller;
+
+import com.wotos.wotosplayerservice.exception.EntityNotFoundException;
+import com.wotos.wotosplayerservice.exception.GlobalExceptionHandler;
+import com.wotos.wotosplayerservice.service.PlayerService;
+import com.wotos.wotosplayerservice.util.model.wot.player.WotPlayer;
+import feign.FeignException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * MockMvc tests covering {@link PlayerController}'s endpoint routes, status codes, and the
+ * integration with {@link GlobalExceptionHandler} for error-response shapes.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PlayerControllerTest {
+
+    @Mock
+    private PlayerService playerService;
+
+    @InjectMocks
+    private PlayerController playerController;
+
+    private MockMvc mockMvc;
+
+    @Before
+    public void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(playerController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    public void getPlayersMapByAccountIdsReturns200() throws Exception {
+        when(playerService.getPlayersMapByAccountIds(any())).thenReturn(new HashMap<>());
+
+        mockMvc.perform(get("/api/players").param("accountIds", "1", "2"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void createPlayersByAccountIdsReturns201() throws Exception {
+        when(playerService.createPlayersByAccountIds(any())).thenReturn(new HashMap<>());
+
+        mockMvc.perform(post("/api/players").param("accountIds", "1"))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    public void updatePlayersByAccountIdsReturns200() throws Exception {
+        when(playerService.updatePlayersByAccountId(any())).thenReturn(new HashMap<>());
+
+        mockMvc.perform(put("/api/players").param("accountIds", "1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void havePlayersBeenUpdatedReturns200() throws Exception {
+        when(playerService.havePlayersBeenUpdated(any())).thenReturn(new HashMap<>());
+
+        mockMvc.perform(get("/api/players/haveUpdated").param("accountIds", "1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getPlayersByNicknameReturns200() throws Exception {
+        when(playerService.getPlayersByNickname(any(), anyString(), any(), anyString()))
+                .thenReturn(Collections.<WotPlayer>emptyList());
+
+        mockMvc.perform(get("/api/players/list")
+                        .param("nicknames", "foo")
+                        .param("searchType", "exact"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void entityNotFoundFromServiceMapsTo404() throws Exception {
+        when(playerService.getPlayersMapByAccountIds(any()))
+                .thenThrow(new EntityNotFoundException("player 1 not found"));
+
+        mockMvc.perform(get("/api/players").param("accountIds", "1"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.message").value("player 1 not found"));
+    }
+
+    @Test
+    public void feignExceptionFromServiceMapsTo502() throws Exception {
+        FeignException feignEx = mock(FeignException.class);
+        when(playerService.createPlayersByAccountIds(any())).thenThrow(feignEx);
+
+        mockMvc.perform(post("/api/players").param("accountIds", "1"))
+                .andExpect(status().isBadGateway())
+                .andExpect(jsonPath("$.status").value(502));
+    }
+}

--- a/src/test/java/com/wotos/wotosplayerservice/controller/PlayerSnapshotControllerTest.java
+++ b/src/test/java/com/wotos/wotosplayerservice/controller/PlayerSnapshotControllerTest.java
@@ -1,0 +1,70 @@
+package com.wotos.wotosplayerservice.controller;
+
+import com.wotos.wotosplayerservice.exception.GlobalExceptionHandler;
+import com.wotos.wotosplayerservice.service.PlayerSnapshotService;
+import feign.FeignException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.HashMap;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * MockMvc tests covering {@link PlayerSnapshotController}'s endpoint routes and the
+ * integration with {@link GlobalExceptionHandler}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PlayerSnapshotControllerTest {
+
+    @Mock
+    private PlayerSnapshotService playerSnapshotService;
+
+    @InjectMocks
+    private PlayerSnapshotController playerSnapshotController;
+
+    private MockMvc mockMvc;
+
+    @Before
+    public void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(playerSnapshotController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    public void getPlayerSnapshotsByAccountIdsReturns200() throws Exception {
+        when(playerSnapshotService.getPlayerSnapshotsByAccountIds(any())).thenReturn(new HashMap<>());
+
+        mockMvc.perform(get("/api/player/snapshots").param("accountIds", "1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void createPlayerSnapshotsByAccountIdsReturns200() throws Exception {
+        when(playerSnapshotService.createPlayerSnapshotByAccountIds(any())).thenReturn(new HashMap<>());
+
+        mockMvc.perform(post("/api/player/snapshots").param("accountIds", "1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void feignExceptionFromServiceMapsTo502() throws Exception {
+        FeignException feignEx = mock(FeignException.class);
+        when(playerSnapshotService.createPlayerSnapshotByAccountIds(any())).thenThrow(feignEx);
+
+        mockMvc.perform(post("/api/player/snapshots").param("accountIds", "1"))
+                .andExpect(status().isBadGateway());
+    }
+}


### PR DESCRIPTION
Closes #2.

## What

Three standalone-MockMvc test classes, one per controller:
- **`PlayerControllerTest`** — 7 tests: happy paths for all five endpoints + `EntityNotFoundException → 404` + `FeignException → 502` shape assertions.
- **`PlayerSnapshotControllerTest`** — 3 tests: happy paths + `FeignException → 502`.
- **`PlayerAchievementsControllerTest`** — 3 tests: happy paths + `FeignException → 502`.

All three wire `GlobalExceptionHandler` via `setControllerAdvice(...)` so error-response shapes are exercised end-to-end. Mockito mocks the service layer; no Spring context or database needed.

## Notes
- Validation-failure → 400 tests are already covered in `GlobalExceptionHandlerTest` (a `@Validated` method-level constraint doesn't trigger from `standaloneSetup`, so testing it at the handler level is the correct slice).
- Closes the "existing controller tests assert error response shapes" gap that #36 left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)